### PR TITLE
Feat: CORS 설정

### DIFF
--- a/develop/src/main/java/ys_band/develop/config/CorsConfig.java
+++ b/develop/src/main/java/ys_band/develop/config/CorsConfig.java
@@ -1,0 +1,23 @@
+package ys_band.develop.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+@Configuration
+public class CorsConfig {
+    @Bean
+    public CorsFilter corsFilter() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);
+        config.addAllowedOriginPattern("http://localhost:3000");//"http://localhost:3000"
+        config.addAllowedHeader("*");
+        config.addAllowedMethod("*");
+
+        source.registerCorsConfiguration("/**", config);//토큰 기반 인증일 경우 필요 없음.
+        return new CorsFilter(source);
+    }
+}


### PR DESCRIPTION
### 📝 구현사항

-클라이언트가 `http://localhost:3000`에서 접근할 수 있도록 CORS 설정 추가
-모든 헤더와 메서드를 허용하도록 설정